### PR TITLE
default access copies arrays.

### DIFF
--- a/lib/redjs/spec/context_spec.rb
+++ b/lib/redjs/spec/context_spec.rb
@@ -293,25 +293,25 @@ shared_examples_for "RedJS::Context", :shared => true do
         def bar(*args); args; end
       end
 
-      expect { 
+      expect {
         @cxt.eval('o.foo(1,2,3)').should == 1
       }.should_not raise_error
-      expect { 
-        @cxt.eval('o.bar(1,2,3)').should == [ 1, 2, 3 ]
+      expect {
+        @cxt.eval('o.bar(1,2,3)').to_a.should == [ 1, 2, 3 ]
       }.should_not raise_error
     end
-    
+
     it "fills in missing arguments with nils to match the arity of the function", :compat => '0.4.3' do
       @instance.instance_eval do
         def foo(a1, a2, a3); [a1, a2, a3]; end
       end
-      
-      expect { 
-        @cxt.eval('o.foo(1)').should == [ 1, nil, nil ]
-        @cxt.eval('o.foo()').should == [ nil, nil, nil ]
+
+      expect {
+        @cxt.eval('o.foo(1)').to_a.should == [ 1, nil, nil ]
+        @cxt.eval('o.foo()').to_a.should == [ nil, nil, nil ]
       }.should_not raise_error
     end
-    
+
     describe "Default Ruby Object Access" do
 
       it "can call public locally defined ruby methods" do


### PR DESCRIPTION
This means that the return value of the eval
should actually be a JS:Array and not a ::Array.
invoking to_a makes sure that the assertion runs
on the elements which is what we're interested in
